### PR TITLE
feat: add Oblivion Server Tool to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@
 - **[PltPatcher](https://github.com/GAMMACASE/PltPatcher)**\
   *A IDA python plugin to patch plt sections when IDA fails to do so automatically, you might encounter such problem when decompiling linux binaries, made by GAMMACASE.*
 
+
+- **[Oblivion Server Tool](https://github.com/oblivion-systems/OblivionServerTool)**\
+  *A desktop application for managing a CS2 dedicated server on Windows. One-click start/stop, map and mode picker, tournament map-veto workflow with Discord bot, and in-app plugin manager.*
+
 # Status Trackers
 
 - **[SteamDB](https://steamdb.info/app/730/charts/)**\


### PR DESCRIPTION
## What

Adds [Oblivion Server Tool](https://github.com/oblivion-systems/OblivionServerTool) to the **Tools** section.

## Description

A desktop application for managing a CS2 dedicated server on Windows. One-click start/stop, map and mode picker, tournament map-veto workflow with Discord bot, and in-app plugin manager.

- Open source (BSL 1.1 → Apache after change date)
- Ships as a single `.exe` installer
- v1.0.0 released June 2026