### PR TITLE
Add cs2-hud-panel — clickable HUD panels for CounterStrikeSharp

### DIFF
--- a/manifests/counterstrikesharp-plugins.json
+++ b/manifests/counterstrikesharp-plugins.json
@@ -366,6 +366,9 @@
   {
     "repo": "zwolof/cs2-executes",
     "desc": "CS2 implementation of executes written in C# for CounterStrikeSharp. Based on the version for CS:GO by Splewis."
-
+  },
+  {
+    "repo": "nvmxre/cs2-hud-panel",
+    "desc": "Clickable, flicker-free HUD panels on the custom_hud_layout entity — one entity with per-player state, Show/Hide/SetText/SetClass and a Clicked event, plus a worked example and a list of the engine gotchas."
   }
 ]


### PR DESCRIPTION
Adds [`nvmxre/cs2-hud-panel`](https://github.com/nvmxre/cs2-hud-panel) to `manifests/counterstrikesharp-plugins.json`.

It is a small MIT library for the `custom_hud_layout` entity Valve shipped on 24 August 2026: a CounterStrikeSharp plugin can drive a Panorama layout and receive mouse clicks back, with the id of the button that was pressed. One entity holds per-player state, so ten players can see different text and different highlights in the same panel. The API is `Show`, `Hide`, `SetText`, `SetClass` and a `Clicked` event.

SwiftlyS2 has a wrapper for this API; CounterStrikeSharp did not, which is why it exists. It ships with a worked example (layout, stylesheet, build script and a 60-line plugin) and a `GOTCHAS.md` listing the engine dead ends with their exact error text.

Checklist from the README:

- Open source — MIT
- Functioning — [v1.0.0](https://github.com/nvmxre/cs2-hud-panel/releases/tag/v1.0.0), in production on our own server

One note: this is a **library** for plugin authors rather than a drop-in plugin, so `Tools` or `Development Resources` may be a better home than the plugins manifest. I put it where the contributing instructions pointed — happy to move it wherever you prefer, just say which file.
